### PR TITLE
Prevent possible security exploit

### DIFF
--- a/UniversalClassLoader.php
+++ b/UniversalClassLoader.php
@@ -246,7 +246,11 @@ class UniversalClassLoader
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
-            require $file;
+            call_user_func(function () use ($file) {
+                ob_start();
+                require $file;
+                ob_end_clean();
+            });
         }
     }
 


### PR DESCRIPTION
While doing development on Respect/Loader a massive security vulnerability was discovered which has the possibility to have huge repercussions as it gives any include file scope to hijack the autoloader.
see Respect/Loader#6 for more information.

This fix will also prevent an included script from auto-outputting anything as a result from the include call which will prevent any unwanted source code from ever being revealed as a result of faulty tags or phising for information when a script manages to be included by someone trying to exploit the application.
