### PR TITLE
Add __call() to XcacheClassLoader

### DIFF
--- a/XcacheClassLoader.php
+++ b/XcacheClassLoader.php
@@ -122,4 +122,13 @@ class XcacheClassLoader
 
         return $file;
     }
+    
+    /**
+     * Passes through all unknown calls onto the decorated object.
+     */
+    public function __call($method, $args)
+    {
+        return call_user_func_array(array($this->classFinder, $method), $args);
+    }
+
 }


### PR DESCRIPTION
XcacheClassLoader does not implement __call() to forward methods (such as addPsr4()) to the decorated object. I think this is an oversight, although I might be missing something. I just copied the code over from ApcClassLoader, which does implement __call().

This allows to use XcacheClassLoader with Drupal 8, as the addPsr4() method is used there.
